### PR TITLE
replace Finder with getNotes

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -5,7 +5,6 @@
 # Source in https://github.com/Arthur-Milchior/anki-relation
 # Addon number 413416269  https://ankiweb.net/shared/info/413416269
 
-from anki.find import Finder
 from anki.notes import Note
 from anki.utils import intTime
 from aqt import mw
@@ -100,8 +99,7 @@ def getNotesFromRelation(relation):
 
 
 def getNidsFromRelations(relations):
-    finder = Finder(mw.col)
-    nids = set(finder.findNotes(queryRelated(relations)))
+    nids = set(mw.col.findNotes(queryRelated(relations)))
     debug(f"from relations {relations} we get nids {nids}")
     return nids
 


### PR DESCRIPTION
This fixes a deprecation warning I noticed when working on a separate PR. `Finder` has been deprecated and access through either `Collection.findNotes` or `Collection.find_notes` appears to be the preferred was now. `.find_notes` only exists after 2.1.24, so I went with `.findNotes` (available since 2012 as far as I can tell) to preserve compatibility.