### PR TITLE
Decrement note count

### DIFF
--- a/burying.py
+++ b/burying.py
@@ -48,6 +48,10 @@ def _burySiblingsAux(self, card, V1):
                 self._revQueue.remove(cid)
             except ValueError:
                 pass
+            else:
+                # decrement note count so Anki doesn't run out of cards and rebuild queues
+                self.revCount -= 1
+
         else:
             # if bury disabled, we still discard to give same-day spacing
             if buryNew:
@@ -56,6 +60,10 @@ def _burySiblingsAux(self, card, V1):
                 self._newQueue.remove(cid)
             except ValueError:
                 pass
+            else:
+                # decrement note count so Anki doesn't run out of cards and rebuild queues
+                self.newCount -= 1
+
     # then bury
     if toBury:
         debug(f"Burying {toBury}")

--- a/burying.py
+++ b/burying.py
@@ -49,8 +49,10 @@ def _burySiblingsAux(self, card, V1):
             except ValueError:
                 pass
             else:
-                # decrement note count so Anki doesn't run out of cards and rebuild queues
-                self.revCount -= 1
+                if card.id != cid:
+                    # decrement count of remaining notes so Anki doesn't run out of cards and rebuild queues
+                    # NOTE: if card.id == cid, the note count has already been decremented by rehearsing
+                    self.revCount -= 1
 
         else:
             # if bury disabled, we still discard to give same-day spacing
@@ -61,8 +63,10 @@ def _burySiblingsAux(self, card, V1):
             except ValueError:
                 pass
             else:
-                # decrement note count so Anki doesn't run out of cards and rebuild queues
-                self.newCount -= 1
+                if card.id != cid:
+                    # decrement count of remaining notes so Anki doesn't run out of cards and rebuild queues
+                    # NOTE: if card.id == cid, the note count has already been decremented by rehearsing
+                    self.newCount -= 1
 
     # then bury
     if toBury:


### PR DESCRIPTION
If we're not burying until the next day when end up exhausting the `sched.revQueue` by burying relations before running out of reviews in the `sched.revCount`, anki will attempt to repopulate the `revQueue` via _fillRev. When that happens, cards that are buried for only the current session will be added back again.

This only happens if the "bury related cards until next day" flag is off.

This can be confirmed by creating a small anki deck with 2 basic cards
- front: "test 1", back: "1"
- front "test 2", back: "2"
and assigning them to be related. After reviewing the first card, the second would normally be buried and not seen again until the next day, but instead Anki will immediately refresh the queue. I've attached a short screenshare of me walking through that test with a sched 2.1 enabled.

https://user-images.githubusercontent.com/4087850/104110079-33abaa80-52a2-11eb-9339-cf499cbd1ffc.mp4

