### PR TITLE
replace Scheduler methods with `wrap` instead of direct assignment

### DIFF
--- a/burying.py
+++ b/burying.py
@@ -5,6 +5,7 @@
 # Source in https://github.com/Arthur-Milchior/anki-relation
 # Addon number 413416269  https://ankiweb.net/shared/info/413416269
 
+from anki.hooks import wrap
 from anki.sched import Scheduler
 from anki.schedv2 import Scheduler as Scheduler2
 # from  anki/sched.py  and anki/schedv2.py
@@ -72,7 +73,11 @@ def _burySiblingsAux(self, card, V1):
         debug("nothing to bury")
 
 
-Scheduler._burySiblings = (
-    lambda self, card: _burySiblingsAux(self, card, True))
-Scheduler2._burySiblings = (
-    lambda self, card: _burySiblingsAux(self, card, False))
+Scheduler._burySiblings = wrap(
+    Scheduler._burySiblings,
+    lambda self, card: _burySiblingsAux(self, card, True),
+    "after")
+Scheduler2._burySiblings = wrap(
+    Scheduler2._burySiblings,
+    lambda self, card: _burySiblingsAux(self, card, False),
+    "after")


### PR DESCRIPTION
directly assigning to _burySiblings means that any plugins that overwrite burySiblings but were loaded first will not work with
this plugin. Using wrap with either "before" or "after" ensures pre-existing before / after actions still get run.

An example of a conflicting plugin: https://github.com/AlexRiina/anki_cousins